### PR TITLE
added room prefix to prevent room hijacking

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The first user gets moderator level access.
 
 ### Setup
 
-Tested with an BBB instance installed with [bbb-install.sh](https://github.com/bigbluebutton/bbb-install). Can be run next to greenlight on the same machine by using different subdirectory and port.
+Tested with an BBB instance installed with [bbb-install.sh](https://github.com/bigbluebutton/bbb-install). Can be run next to greenlight on the same machine by using different subdirectory and port. Can also be run on a different machine than BBB using below instructions.
 
 Installation requires git and bbb to be installed on the same machine
 
@@ -50,6 +50,26 @@ sed -i 's|/easy|/subdirname|g' app.js bbb-easy-join.nginx views/index.ejs views/
 systemctl reload nginx && systemctl restart bbb-easy-join.service
 ```
 Now bbb-easy-join is served on /subdirname (change to your likeings)
+
+### run on a different server than bbb
+The frontend van be run on a different server than the actual bbb. 
+
+Installation requires git and nodejs 12 to be installed on the same machine
+
+```bash
+curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash -
+sudo apt install git nodejs
+```
+
+Checkout this repository to /var/www/bbb-easy-join
+
+```
+git clone https://github.com/svoeth/bbb-easy-join.git /var/www/bbb-easy-join
+cd /var/www/bbb-easy-join
+npm install
+```
+
+Add the line `user
 
 
 ### Note

--- a/app.js
+++ b/app.js
@@ -142,7 +142,7 @@ app.post('/easy', async function (req, res) {
   }
 
   //slugify roomName because room contains prefix
-  res.redirect('/easy/' + room )
+  res.redirect('/easy/' + slugify(roomName, { lower: true }))
 })
 
 app.get('/easy/:room', async function (req, res){

--- a/app.js
+++ b/app.js
@@ -88,7 +88,8 @@ app.get('/easy', function (req, res) {
 // if password is set provide mod and user pw for welcome message
 app.post('/easy', async function (req, res) {
   var roomName = req.body.room
-  var room = slugify(roomName, { lower: true })
+  //easy-prefix is used to mark the room as created by this frontend
+  var room = "easy-" + slugify(roomName, { lower: true })
 
   // if user provides password within room creation, set prefix "user-"  otherwise set it to "auto-"
   var room_password;
@@ -146,7 +147,8 @@ app.post('/easy', async function (req, res) {
 
 app.get('/easy/:room', async function (req, res){
   // added slugify lower to prevent error if accidental uppercase or special characters are in adress
-  var room = slugify(req.params.room, { lower: true })
+  //easy-prefix is used to only handle rooms created by this frontend
+  var room = "easy-" + slugify(req.params.room, { lower: true })
   var info = await getMeetingInfo(room)
 
   //check if meeting info was not succesfully grabbed and in case redirect with error message (room not created)


### PR DESCRIPTION
### Room prefix
**New:**
(c6a2f72): Room now get an internal prefix ("easy-"). This way it is not possible to (accidentally) hijack a room which is for example "reserved" by greenlight.

(1cac515): bugfix

(3c6dc59): Addition to readme file to freely change subdir name